### PR TITLE
add minimal Lyapunov certificate example

### DIFF
--- a/DynamicalSystems.lean
+++ b/DynamicalSystems.lean
@@ -23,3 +23,4 @@ import DynamicalSystems.Stability.InputToState
 import DynamicalSystems.Stability.Example
 import DynamicalSystems.Stability.LaSalle
 import DynamicalSystems.Stability.Lyapunov
+import DynamicalSystems.Stability.MinimalCertificate

--- a/DynamicalSystems/Stability/MinimalCertificate.lean
+++ b/DynamicalSystems/Stability/MinimalCertificate.lean
@@ -1,0 +1,38 @@
+/-
+Copyright (c) 2026 Inacio Vasquez. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Inacio Vasquez
+-/
+
+module public import DynamicalSystems.Stability.Example
+
+/-!
+# Minimal Lyapunov certificate example
+
+This file records a small downstream certificate surface for the existing
+one-dimensional linear-decay example.
+
+It does not introduce a new stability theorem.  It gives a named, testable
+certificate layer over the existing Lyapunov example:
+`x ↦ x ^ 2` for the flow `x' = -r x`, with `0 ≤ r`.
+-/
+
+@[expose] public noncomputable section
+
+open scoped Topology
+
+namespace DynamicalSystems
+
+/-- Minimal certificate: `x ↦ x ^ 2` is a Lyapunov function for the
+one-dimensional linear decay flow `x' = -r x`, assuming `0 ≤ r`. -/
+theorem minimalLyapunovCertificate_linear_decay {r : ℝ} (hr : 0 ≤ r) :
+    IsLyapunov (fun x : ℝ => x ^ 2) (smulFlow (-r)) :=
+  _root_.isLyapunov_sq_smulFlow hr
+
+/-- Minimal certified consequence: the origin is forward stable for the same
+one-dimensional linear decay flow. -/
+theorem minimalLyapunovCertificate_linear_decay_stable {r : ℝ} (hr : 0 ≤ r) :
+    (𝓝 (0 : ℝ)).IsStableOn (smulFlow (-r)) (Set.Ici (0 : ℝ)) :=
+  _root_.isStableOn_smulFlow hr
+
+end DynamicalSystems

--- a/artifacts/dynamics/minimal_lyapunov_certificate_example_2026_06_03T210544Z.json
+++ b/artifacts/dynamics/minimal_lyapunov_certificate_example_2026_06_03T210544Z.json
@@ -1,0 +1,27 @@
+{
+  "object": "MINIMAL_LYAPUNOV_CERTIFICATE_EXAMPLE",
+  "timestamp_utc": "2026_06_03T210544Z",
+  "repository": "mcdoll/DynamicalSystems fork",
+  "status": "MINIMAL_EXAMPLE_REEXPORT_ONLY",
+  "lean_module": "DynamicalSystems.Stability.MinimalCertificate",
+  "closed_objects": [
+    "DynamicalSystems.minimalLyapunovCertificate_linear_decay",
+    "DynamicalSystems.minimalLyapunovCertificate_linear_decay_stable"
+  ],
+  "proves": [
+    "For r >= 0, x ↦ x^2 is an IsLyapunov function for the existing one-dimensional flow smulFlow (-r).",
+    "For r >= 0, the origin is forward stable for the existing one-dimensional flow smulFlow (-r)."
+  ],
+  "not_proven": [
+    "new stability theorem",
+    "global stability for arbitrary nonlinear systems",
+    "global asymptotic stability for arbitrary nonlinear systems",
+    "exponential stability",
+    "converse Lyapunov theorem",
+    "LaSalle theorem generalization",
+    "mathlib upstream acceptance",
+    "control-theory maintainership resolution",
+    "new applied-dynamics result"
+  ],
+  "minimal_next_object": "MaintainerFeedbackOrConcreteNonlinearCertificateExample"
+}

--- a/docs/status/MINIMAL_LYAPUNOV_CERTIFICATE_EXAMPLE_2026_06_03T210544Z.md
+++ b/docs/status/MINIMAL_LYAPUNOV_CERTIFICATE_EXAMPLE_2026_06_03T210544Z.md
@@ -1,0 +1,33 @@
+# Minimal Lyapunov Certificate Example
+
+STATUS: MINIMAL_EXAMPLE_REEXPORT_ONLY
+
+Lean module:
+
+- `DynamicalSystems.Stability.MinimalCertificate`
+
+Closed objects:
+
+- `DynamicalSystems.minimalLyapunovCertificate_linear_decay`
+- `DynamicalSystems.minimalLyapunovCertificate_linear_decay_stable`
+
+What this proves:
+
+- For `r >= 0`, `x ↦ x^2` is an `IsLyapunov` function for the existing one-dimensional flow `smulFlow (-r)`.
+- For `r >= 0`, the origin is forward stable for the existing one-dimensional flow `smulFlow (-r)`.
+
+Does not prove:
+
+- new stability theorem
+- global stability for arbitrary nonlinear systems
+- global asymptotic stability for arbitrary nonlinear systems
+- exponential stability
+- converse Lyapunov theorem
+- LaSalle theorem generalization
+- mathlib upstream acceptance
+- control-theory maintainership resolution
+- new applied-dynamics result
+
+Minimal next object:
+
+`MaintainerFeedbackOrConcreteNonlinearCertificateExample`

--- a/tests/test_minimal_lyapunov_certificate_boundary.py
+++ b/tests/test_minimal_lyapunov_certificate_boundary.py
@@ -1,0 +1,12 @@
+import subprocess
+import sys
+
+
+def test_minimal_lyapunov_certificate_boundary():
+    result = subprocess.run(
+        [sys.executable, "tools/verify_minimal_lyapunov_certificate_boundary.py"],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    assert "MINIMAL_LYAPUNOV_CERTIFICATE_BOUNDARY_OK" in result.stdout

--- a/tools/verify_minimal_lyapunov_certificate_boundary.py
+++ b/tools/verify_minimal_lyapunov_certificate_boundary.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+import json
+from pathlib import Path
+
+artifacts = sorted(Path("artifacts/dynamics").glob("minimal_lyapunov_certificate_example_*.json"))
+assert artifacts, "missing minimal Lyapunov certificate artifact"
+
+data = json.loads(artifacts[-1].read_text())
+
+assert data["status"] == "MINIMAL_EXAMPLE_REEXPORT_ONLY"
+assert data["lean_module"] == "DynamicalSystems.Stability.MinimalCertificate"
+
+closed = set(data["closed_objects"])
+assert "DynamicalSystems.minimalLyapunovCertificate_linear_decay" in closed
+assert "DynamicalSystems.minimalLyapunovCertificate_linear_decay_stable" in closed
+
+not_proven = set(data["not_proven"])
+required_boundaries = {
+    "new stability theorem",
+    "global stability for arbitrary nonlinear systems",
+    "global asymptotic stability for arbitrary nonlinear systems",
+    "exponential stability",
+    "converse Lyapunov theorem",
+    "LaSalle theorem generalization",
+    "mathlib upstream acceptance",
+    "control-theory maintainership resolution",
+    "new applied-dynamics result",
+}
+missing = required_boundaries - not_proven
+assert not missing, f"missing boundary tokens: {sorted(missing)}"
+
+for field in ("proves", "closed_objects"):
+    text = " ".join(data[field]).lower()
+    forbidden = [
+        "arbitrary nonlinear",
+        "converse lyapunov",
+        "exponential stability",
+        "new applied-dynamics result",
+        "mathlib upstream acceptance",
+    ]
+    bad = [token for token in forbidden if token in text]
+    assert not bad, f"overclaim in {field}: {bad}"
+
+print("MINIMAL_LYAPUNOV_CERTIFICATE_BOUNDARY_OK")


### PR DESCRIPTION
Adds a minimal downstream Lyapunov certificate example over the existing one-dimensional linear-decay stability example.

Closed objects:
- DynamicalSystems.minimalLyapunovCertificate_linear_decay
- DynamicalSystems.minimalLyapunovCertificate_linear_decay_stable

Boundary:
- no new stability theorem
- no arbitrary nonlinear-system theorem
- no exponential-stability theorem
- no converse Lyapunov theorem
- no LaSalle generalization
- no mathlib upstream claim
- no new applied-dynamics result

Verification:
- lake build DynamicalSystems.Stability.MinimalCertificate
- python3 tools/verify_minimal_lyapunov_certificate_boundary.py
- python3 -m pytest -q tests/test_minimal_lyapunov_certificate_boundary.py
